### PR TITLE
Support for py2 and py3

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+jujubundlelib (0.1.9-2ubuntu2) wily; urgency=medium
+
+  * Make jujubundlelib transitional package
+
+ -- Marco Ceppi <marco@ceppi.net>  Wed, 02 Sep 2015 06:28:52 -0400
+
 jujubundlelib (0.1.9-2ubuntu1) wily; urgency=medium
 
   * Added python-jujubundlelib and python3-jujubundlelib targets

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+jujubundlelib (0.1.9-2ubuntu1) wily; urgency=medium
+
+  * Added python-jujubundlelib and python3-jujubundlelib targets
+
+ -- Marco Ceppi <marco@ceppi.net>  Tue, 01 Sep 2015 17:43:58 -0400
+
 jujubundlelib (0.1.9-1) trusty; urgency=low
 
   * Improve machines section validation.

--- a/control
+++ b/control
@@ -9,15 +9,30 @@ Build-Depends:
  python-setuptools,
  python-nose,
  python-mock,
- python-yaml
+ python-yaml,
+ python3-all (>= 3.1),
+ python3-setuptools (>= 0.6b3)
 XS-Python-Version: all
+X-Python3-Version: >= 3.1
+X-Python-Version: >= 2.6
 Homepage: https://github.com/juju/juju-bundlelib
 
 Package: jujubundlelib
 Architecture: all
 XB-Python-Version: ${python:Versions}
-Depends: ${python:Depends}, ${misc:Depends}
+Depends: ${python:Depends}, ${misc:Depends}, python-jujubundlelib
 Provides: ${python:Provides}
 Description: A Python library for working with Juju bundles.
  Juju Bundle Lib is a library for processing and validating Juju bundles.
  It also defines Python bindings for working with charm and bundle references.
+
+Package: python-jujubundlelib
+Architecture: all
+Depends: ${misc:Depends}, ${python:Depends}, python-yaml
+Description: A python 2 library for working with Juju bundles
+
+Package: python3-jujubundlelib
+Architecture: all
+Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml
+Description: A python 3 library for working with Juju bundles
+

--- a/control
+++ b/control
@@ -22,17 +22,22 @@ Architecture: all
 XB-Python-Version: ${python:Versions}
 Depends: ${python:Depends}, ${misc:Depends}, python-jujubundlelib
 Provides: ${python:Provides}
-Description: A Python library for working with Juju bundles.
- Juju Bundle Lib is a library for processing and validating Juju bundles.
- It also defines Python bindings for working with charm and bundle references.
+Description: transitional dummy package
+ This is a transitional dummy package. It can safely be removed.
 
 Package: python-jujubundlelib
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-yaml
-Description: A python 2 library for working with Juju bundles
+Breaks: jujubundlelib (<< 0.1.9-1~)
+Replaces: jujubundlelib (<< 0.1.9-1~)
+Description: A Python2 library for working with Juju bundles.
+ Juju Bundle Lib is a library for processing and validating Juju bundles.
+ It also defines Python bindings for working with charm and bundle references.
 
 Package: python3-jujubundlelib
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml
-Description: A python 3 library for working with Juju bundles
+Description: A Python 3 library for working with Juju bundles.
+ Juju Bundle Lib is a library for processing and validating Juju bundles.
+ It also defines Python bindings for working with charm and bundle references.
 

--- a/juju-bundlelib.install
+++ b/juju-bundlelib.install
@@ -1,1 +1,0 @@
-jujubundlelib/*        /usr/share/pyshared/jujubundlelib

--- a/python-jujubundlelib.install
+++ b/python-jujubundlelib.install
@@ -1,0 +1,1 @@
+usr/lib/python2.*/

--- a/python3-jujubundlelib.install
+++ b/python3-jujubundlelib.install
@@ -1,0 +1,1 @@
+usr/lib/python3/

--- a/rules
+++ b/rules
@@ -1,16 +1,14 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+
+PYTHON3 := $(shell py3versions -r)
+
 %:
-	dh $@ --with python2 --buildsystem=python_distutils
+	dh $@ --with python2,python3
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
@@ -20,3 +18,21 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 else
 		@echo "** tests disabled"
 endif
+
+override_dh_auto_clean:
+	dh_auto_clean
+	rm -rf build/
+
+override_dh_auto_build:
+	# Build for each Python 3 version
+	set -ex; for python in $(PYTHON3); do \
+		$$python setup.py build; \
+	done
+	dh_auto_build
+
+override_dh_auto_install:
+	# The same for install; note the --install-layout=deb option
+	set -ex; for python in $(PYTHON3); do \
+		$$python setup.py install --install-layout=deb --root=debian/tmp; \
+	done
+	dh_auto_install


### PR DESCRIPTION
This creates jujubundlelib as a transitional package (so packages that depend on it currently, quickstart, etc will still work - though when you get a chance renaming to python-jujubundlelib will mean we can remove this transitional package) and creates two new packages python-jujubundlelib which replaces the original jujubundlelib package and python3-jujubundlelib which will build the py3 compatible package.

This is the same original source package for jujubundlelib so there's no need to delete or remove packages from the archive.

New instructions for the build process are here: https://github.com/juju/juju-bundlelib/pull/35
