### PR TITLE
Misunderstood ~ in deb packaging, this fixes broken upgrades

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+jujubundlelib (0.1.9-2ubuntu4) UNRELEASED; urgency=medium
+
+  * Make brakes and replaces << 0.1.9-2~ which is the proper version string
+
+ -- Marco Ceppi <marco@ceppi.net>  Wed, 02 Sep 2015 12:59:35 -0400
+
+jujubundlelib (0.1.9-2ubuntu3) wily; urgency=medium
+
+  * Make break and replaces <= instead of <<
+
+ -- Marco Ceppi <marco@ceppi.net>  Wed, 02 Sep 2015 12:33:05 -0400
+
 jujubundlelib (0.1.9-2ubuntu2) wily; urgency=medium
 
   * Make jujubundlelib transitional package

--- a/control
+++ b/control
@@ -28,8 +28,8 @@ Description: transitional dummy package
 Package: python-jujubundlelib
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-yaml
-Breaks: jujubundlelib (<< 0.1.9-1~)
-Replaces: jujubundlelib (<< 0.1.9-1~)
+Breaks: jujubundlelib (<< 0.1.9-2)
+Replaces: jujubundlelib (<< 0.1.9-2)
 Description: A Python2 library for working with Juju bundles.
  Juju Bundle Lib is a library for processing and validating Juju bundles.
  It also defines Python bindings for working with charm and bundle references.


### PR DESCRIPTION
This is a typo and mistake on my part when creating the transition package. Instead of doing all versions less than 0.1.9-1 we need to do all versions less than the version that adds the transition (0.1.9-2) I've updated the build in the ppa and validated that upgrading from 0.1.9-1 to 0.1.9-2ubuntu4 is clean and does not break.
